### PR TITLE
fix kvs producer busy loop when audio is enabled

### DIFF
--- a/component/common/example/kvs_producer/kvs_producer.c
+++ b/component/common/example/kvs_producer/kvs_producer.c
@@ -701,7 +701,7 @@ static void streamFlushToNextCluster(StreamHandle xStreamHandle)
     }
 }
 
-static int putMediaSendData(Kvs_t *pKvs)
+static int putMediaSendData(Kvs_t *pKvs, int *pxSendCnt)
 {
     int res = 0;
     DataFrameHandle xDataFrameHandle = NULL;
@@ -710,6 +710,7 @@ static int putMediaSendData(Kvs_t *pKvs)
     size_t uDataLen = 0;
     uint8_t *pMkvHeader = NULL;
     size_t uMkvHeaderLen = 0;
+    int xSendCnt = 0;
 
     if (Kvs_streamAvailOnTrack(pKvs->xStreamHandle, TRACK_VIDEO)
 #if ENABLE_AUDIO_TRACK
@@ -734,7 +735,7 @@ static int putMediaSendData(Kvs_t *pKvs)
         }
         else
         {
-
+            xSendCnt++;
         }
 
         if (xDataFrameHandle != NULL)
@@ -743,6 +744,11 @@ static int putMediaSendData(Kvs_t *pKvs)
             free(pDataFrameIn->pData);
             Kvs_dataFrameTerminate(xDataFrameHandle);
         }
+    }
+
+    if (pxSendCnt != NULL)
+    {
+        *pxSendCnt = xSendCnt;
     }
 
     return res;
@@ -754,6 +760,7 @@ static int putMedia(Kvs_t *pKvs)
     unsigned int uHttpStatusCode = 0;
     uint8_t *pEbmlSeg = NULL;
     size_t uEbmlSegLen = 0;
+	int xSendCnt = 0;
 
     printf("Try to put media\r\n");
     if (pKvs == NULL)
@@ -779,7 +786,7 @@ static int putMedia(Kvs_t *pKvs)
 
         while (1)
         {
-            if (putMediaSendData(pKvs) != ERRNO_NONE)
+            if (putMediaSendData(pKvs, &xSendCnt) != ERRNO_NONE)
             {
                 break;
             }
@@ -787,7 +794,7 @@ static int putMedia(Kvs_t *pKvs)
             {
                 break;
             }
-            if (Kvs_streamIsEmpty(pKvs->xStreamHandle))
+            if (xSendCnt == 0)
             {
                 sleepInMs(50);
             }


### PR DESCRIPTION
Issue: When audio is enabled, the putMedia loop won't send frame unless there are available video and audio frames.  It makes the loop isn't empty and doesn't sleep.

Solution: Instead of check if the stream buffer is empty, it can be fixed by checking the send count.  If the send count is zero, then it means there is no action in current loop and it can sleep a little.